### PR TITLE
Rewrite build pipeline with harfbuzzjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 dist/
 src/
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+This repo produces a size-reduced subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk/) font (v2.004). It is not a runtime library — it is a build pipeline that takes upstream `.otf` files and emits `.min.ttf`, `.min.woff`, and `.min.woff2` covering only the character ranges declared under `Letters/`.
+
+## Build pipeline
+
+- `npm install` once, then `npm start` (i.e. `node index.js`) is the only build command.
+- `index.js` does three things in order:
+  1. Concatenates every file under `Letters/` into an in-memory string — the union of glyphs to keep. (No temp file on disk.)
+  2. Scans `src/` for `*.otf` and `*.ttf` source fonts.
+  3. For each font × `{sfnt, woff, woff2}` calls `harfbuzzjs/hb-subset.wasm` directly to subset the input, **dropping the `GSUB`, `GPOS`, `GDEF`, `kern`, `morx`, `mort` tables** via `HB_SUBSET_SETS_DROP_TABLE_TAG`, then wraps the result in the requested format via [`fontverter`](https://github.com/papandreou/fontverter). The output is written as `<name>.min.{ttf,woff,woff2}` under `dist/`. The output preserves the input outline format (CFF/CFF2 for OTF, glyf for TTF) under the `.min.ttf` extension — `.min.ttf` for an OTF source is technically OTF-inside-a-.ttf-named-file, which every browser handles.
+- Stripping the layout tables is the main size reduction lever: CJK GSUB lookups (alternates, vertical forms, etc.) and GPOS kerning data dwarf the actual glyph outlines for a small subset. Browsers fall back to default glyph mapping without GSUB/GPOS, which is fine for Web body text. If a future build needs vertical writing or kerning, narrow `DROP_TABLES` in `index.js`.
+
+## Prerequisites
+
+- **Node 18+** (for `fs/promises`). The pipeline is pure JS/WASM — `npm install` pulls `harfbuzzjs` (the harfbuzz-subset wasm binary) and `fontverter`. No Python, no `pyftsubset`, no native compile.
+- **Source `.otf` or `.ttf` files** must be placed in `src/` manually. `src/` is `.gitignored` — it is not checked in. Get them from the upstream Noto release.
+- **`dist/`** is also `.gitignored`. The `docs/Fonts/NotoSansCJKjp/` directory contains a *published* copy of the subset used by the demo page; it is committed and is not the same as `dist/`.
+
+## Character set layout (`Letters/`)
+
+Each file is one slice of the kept glyph set. Adding/removing a file or editing its contents directly changes which characters survive the subset — the README's character tables mirror these files and should be updated in lockstep.
+
+- `ASCII.txt` — 124 chars
+- `Hiragana, Katakana, etc.txt` — 523 chars (kana, punctuation, Greek, Cyrillic, box-drawing, etc.)
+- `JIS Level-1 Kanji Set.txt` — 2,965 chars
+- `JIS Level-2 Kanji Set (Only one part).txt` — 551 chars (intentionally a partial JIS L2 — adding more would defeat the size goal)
+
+## `docs/` is GitHub Pages
+
+`docs/` is the demo site published at `hiz8.github.io/Noto-Sans-CJK-JP.min/`. `docs/index.html` is Japanese; `docs/en/index.html` is English. The fonts referenced from the demo live in `docs/Fonts/NotoSansCJKjp/` and are committed artifacts — when shipping a new build, the relevant files need to be copied from `dist/` into `docs/Fonts/NotoSansCJKjp/`.
+
+## Conventions
+
+- Prettier is configured (`.prettierrc`: `singleQuote`, `trailingComma: all`) but there is no lint/test script — formatting is the only style enforcement and there is no test suite.
+- License for the fonts themselves is SIL OFL (`OFL.txt`); the build script has no separate license header.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Purpose
 
-This repo produces a size-reduced subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk/) font (v2.004). It is not a runtime library — it is a build pipeline that takes upstream `.otf` files and emits `.min.ttf`, `.min.woff`, and `.min.woff2` covering only the character ranges declared under `Letters/`.
+This repo produces a size-reduced subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk/) font (v2.004). It is not a runtime library — it is a build pipeline that takes upstream `.otf` (or `.ttf`) source files and emits `.min.ttf`, `.min.woff`, and `.min.woff2` covering only the character ranges declared under `Letters/`.
 
 ## Build pipeline
 
@@ -13,7 +13,7 @@ This repo produces a size-reduced subset of the [Noto Sans CJK JP](http://www.go
   1. Concatenates every file under `Letters/` into an in-memory string — the union of glyphs to keep. (No temp file on disk.)
   2. Scans `src/` for `*.otf` and `*.ttf` source fonts.
   3. For each font × `{sfnt, woff, woff2}` calls `harfbuzzjs/hb-subset.wasm` directly to subset the input, **dropping the `GSUB`, `GPOS`, `GDEF`, `kern`, `morx`, `mort` tables** via `HB_SUBSET_SETS_DROP_TABLE_TAG`, then wraps the result in the requested format via [`fontverter`](https://github.com/papandreou/fontverter). The output is written as `<name>.min.{ttf,woff,woff2}` under `dist/`. The output preserves the input outline format (CFF/CFF2 for OTF, glyf for TTF) under the `.min.ttf` extension — `.min.ttf` for an OTF source is technically OTF-inside-a-.ttf-named-file, which every browser handles.
-- Stripping the layout tables is the main size reduction lever: CJK GSUB lookups (alternates, vertical forms, etc.) and GPOS kerning data dwarf the actual glyph outlines for a small subset. Browsers fall back to default glyph mapping without GSUB/GPOS, which is fine for Web body text. If a future build needs vertical writing or kerning, narrow `DROP_TABLES` in `index.js`.
+- Stripping the layout tables is the main size reduction lever: CJK GSUB lookups (alternates, vertical forms, etc.) and GPOS kerning data dwarf the actual glyph outlines for a small subset. Browsers fall back to default glyph mapping without GSUB/GPOS, which is fine for horizontal Web body text. Trade-off: vertical writing (`vert`/`vrt2`) and a few CJK punctuation alternates regress because they rely on GSUB substitutions; kerning is lost with GPOS. If a future build needs any of those, narrow `DROP_TABLES` in `index.js`.
 
 ## Prerequisites
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ const SRC_DIR = path.join(__dirname, 'src');
 const DIST_DIR = path.join(__dirname, 'dist');
 const SRC_EXT = /\.(otf|ttf)$/i;
 
+// fontverter labels SFNT-flavored output (CFF/CFF2/glyf) as 'truetype'
+// regardless of the inner outline format.
+const SFNT = 'truetype';
+
 const TARGETS = [
   { format: 'sfnt', ext: 'ttf' },
   { format: 'woff', ext: 'woff' },
@@ -34,30 +38,37 @@ async function loadHarfbuzz() {
       const {
         instance: { exports: hb },
       } = await WebAssembly.instantiate(wasm);
-      return { hb, heap: new Uint8Array(hb.memory.buffer) };
+      return hb;
     })();
   }
   return hbInit;
 }
 
-async function subsetAndStrip(originalFont, text, targetFormat) {
-  const { hb, heap } = await loadHarfbuzz();
+// WASM linear memory may grow on malloc, detaching previously-captured
+// ArrayBuffer views. Re-derive at point of use rather than caching.
+const heapOf = (hb) => new Uint8Array(hb.memory.buffer);
+
+async function subsetToSfnt(originalFont, text) {
+  const hb = await loadHarfbuzz();
 
   // harfbuzz's hb-subset only accepts SFNT input.
-  const sfntInput = await fontverter.convert(originalFont, 'truetype');
+  const sfntInput = await fontverter.convert(originalFont, SFNT);
 
   const input = hb.hb_subset_input_create_or_fail();
   if (input === 0) {
     throw new Error('hb_subset_input_create_or_fail returned zero');
   }
 
-  const fontPtr = hb.malloc(sfntInput.byteLength);
-  heap.set(new Uint8Array(sfntInput), fontPtr);
-  const blob = hb.hb_blob_create(fontPtr, sfntInput.byteLength, 2, 0, 0);
-  const face = hb.hb_face_create(blob, 0);
-  hb.hb_blob_destroy(blob);
-
+  let fontPtr = 0;
+  let face = 0;
+  let subset = 0;
   try {
+    fontPtr = hb.malloc(sfntInput.byteLength);
+    heapOf(hb).set(new Uint8Array(sfntInput), fontPtr);
+    const blob = hb.hb_blob_create(fontPtr, sfntInput.byteLength, 2, 0, 0);
+    face = hb.hb_face_create(blob, 0);
+    hb.hb_blob_destroy(blob);
+
     const dropSet = hb.hb_subset_input_set(input, HB_SUBSET_SETS_DROP_TABLE_TAG);
     for (const tag of DROP_TABLES) {
       hb.hb_set_add(dropSet, hbTag(tag));
@@ -75,25 +86,22 @@ async function subsetAndStrip(originalFont, text, targetFormat) {
       hb.hb_set_add(unicodes, c.codePointAt(0));
     }
 
-    const subset = hb.hb_subset_or_fail(face, input);
+    subset = hb.hb_subset_or_fail(face, input);
     if (subset === 0) {
       throw new Error('hb_subset_or_fail returned zero');
     }
 
-    try {
-      const result = hb.hb_face_reference_blob(subset);
-      const offset = hb.hb_blob_get_data(result, 0);
-      const length = hb.hb_blob_get_length(result);
-      const out = Buffer.from(heap.subarray(offset, offset + length));
-      hb.hb_blob_destroy(result);
-      return await fontverter.convert(out, targetFormat, 'truetype');
-    } finally {
-      hb.hb_face_destroy(subset);
-    }
+    const result = hb.hb_face_reference_blob(subset);
+    const offset = hb.hb_blob_get_data(result, 0);
+    const length = hb.hb_blob_get_length(result);
+    const out = Buffer.from(heapOf(hb).subarray(offset, offset + length));
+    hb.hb_blob_destroy(result);
+    return out;
   } finally {
+    if (subset) hb.hb_face_destroy(subset);
+    if (face) hb.hb_face_destroy(face);
     hb.hb_subset_input_destroy(input);
-    hb.hb_face_destroy(face);
-    hb.free(fontPtr);
+    if (fontPtr) hb.free(fontPtr);
   }
 }
 
@@ -102,7 +110,7 @@ async function readGlyphSet() {
   const parts = await Promise.all(
     files.map((f) => fs.readFile(path.join(LETTERS_DIR, f), 'utf8')),
   );
-  return parts.map((s) => s.replace(/^﻿/, '')).join('');
+  return parts.map((s) => s.replace(/^\uFEFF/, '')).join('');
 }
 
 async function listSrcFonts() {
@@ -114,13 +122,21 @@ async function listSrcFonts() {
 
 async function buildOne(srcFile, text) {
   const baseName = srcFile.replace(SRC_EXT, '');
-  const input = await fs.readFile(path.join(SRC_DIR, srcFile));
-  let failed = 0;
 
+  let sfntSubset;
+  try {
+    const input = await fs.readFile(path.join(SRC_DIR, srcFile));
+    sfntSubset = await subsetToSfnt(input, text);
+  } catch (e) {
+    console.error(`  subset failed: ${e.message}`);
+    return TARGETS.length;
+  }
+
+  let failed = 0;
   for (const { format, ext } of TARGETS) {
     const outPath = path.join(DIST_DIR, `${baseName}.min.${ext}`);
     try {
-      const out = await subsetAndStrip(input, text, format);
+      const out = await fontverter.convert(sfntSubset, format, SFNT);
       await fs.writeFile(outPath, out);
       console.log(
         `  ${path.basename(outPath)}  (${out.length.toLocaleString()} bytes)`,

--- a/index.js
+++ b/index.js
@@ -1,95 +1,161 @@
-const fs = require('fs');
-const exec = require('child_process').execSync;
+const fs = require('fs/promises');
+const path = require('path');
+const fontverter = require('fontverter');
 
-const config = {
-  lettersPath: './Letters/',
-  inputPath: './src/',
-  outputPath: './dist/',
-};
+const LETTERS_DIR = path.join(__dirname, 'Letters');
+const SRC_DIR = path.join(__dirname, 'src');
+const DIST_DIR = path.join(__dirname, 'dist');
+const SRC_EXT = /\.(otf|ttf)$/i;
 
-async function genTextsFromFile() {
-  const textDir = await fs.promises
-    .readdir(config.lettersPath)
-    .catch(err => console.error(err));
-  let letters = '';
-  let num = 0;
+const TARGETS = [
+  { format: 'sfnt', ext: 'ttf' },
+  { format: 'woff', ext: 'woff' },
+  { format: 'woff2', ext: 'woff2' },
+];
 
-  for (let i = 0; i < textDir.length; i++) {
-    const textFile = textDir[i];
-    let textFilePath = config.lettersPath + textFile;
+// OpenType layout tables to strip from the subset output. Removing these is
+// what gives the WOFF/WOFF2 a step-change size reduction over a plain subset:
+// CJK GSUB lookups (ligatures, alternates, vertical forms, etc.) are huge.
+// Web rendering does not need them — browsers fall back to default glyphs.
+const DROP_TABLES = ['GSUB', 'GPOS', 'GDEF', 'kern', 'morx', 'mort'];
 
-    const letter = await fs.promises
-      .readFile(textFilePath, 'utf-8')
-      .catch(err => console.error(err));
+const HB_SUBSET_SETS_DROP_TABLE_TAG = 3;
+const HB_SUBSET_FLAGS_NO_LAYOUT_CLOSURE = 0x00000200;
 
-    letters += letter;
-    num++;
+const hbTag = (s) =>
+  s.split('').reduce((a, c) => (a << 8) + c.charCodeAt(0), 0) >>> 0;
 
-    if (num === textDir.length) {
-      return letters;
+let hbInit;
+async function loadHarfbuzz() {
+  if (!hbInit) {
+    hbInit = (async () => {
+      const wasmPath = require.resolve('harfbuzzjs/hb-subset.wasm');
+      const wasm = await fs.readFile(wasmPath);
+      const {
+        instance: { exports: hb },
+      } = await WebAssembly.instantiate(wasm);
+      return { hb, heap: new Uint8Array(hb.memory.buffer) };
+    })();
+  }
+  return hbInit;
+}
+
+async function subsetAndStrip(originalFont, text, targetFormat) {
+  const { hb, heap } = await loadHarfbuzz();
+
+  // harfbuzz's hb-subset only accepts SFNT input.
+  const sfntInput = await fontverter.convert(originalFont, 'truetype');
+
+  const input = hb.hb_subset_input_create_or_fail();
+  if (input === 0) {
+    throw new Error('hb_subset_input_create_or_fail returned zero');
+  }
+
+  const fontPtr = hb.malloc(sfntInput.byteLength);
+  heap.set(new Uint8Array(sfntInput), fontPtr);
+  const blob = hb.hb_blob_create(fontPtr, sfntInput.byteLength, 2, 0, 0);
+  const face = hb.hb_face_create(blob, 0);
+  hb.hb_blob_destroy(blob);
+
+  try {
+    const dropSet = hb.hb_subset_input_set(input, HB_SUBSET_SETS_DROP_TABLE_TAG);
+    for (const tag of DROP_TABLES) {
+      hb.hb_set_add(dropSet, hbTag(tag));
+    }
+
+    // GSUB is being dropped, so layout closure would only waste work and keep
+    // glyphs that aren't reachable without GSUB anyway.
+    hb.hb_subset_input_set_flags(
+      input,
+      hb.hb_subset_input_get_flags(input) | HB_SUBSET_FLAGS_NO_LAYOUT_CLOSURE,
+    );
+
+    const unicodes = hb.hb_subset_input_unicode_set(input);
+    for (const c of text) {
+      hb.hb_set_add(unicodes, c.codePointAt(0));
+    }
+
+    const subset = hb.hb_subset_or_fail(face, input);
+    if (subset === 0) {
+      throw new Error('hb_subset_or_fail returned zero');
+    }
+
+    try {
+      const result = hb.hb_face_reference_blob(subset);
+      const offset = hb.hb_blob_get_data(result, 0);
+      const length = hb.hb_blob_get_length(result);
+      const out = Buffer.from(heap.subarray(offset, offset + length));
+      hb.hb_blob_destroy(result);
+      return await fontverter.convert(out, targetFormat, 'truetype');
+    } finally {
+      hb.hb_face_destroy(subset);
+    }
+  } finally {
+    hb.hb_subset_input_destroy(input);
+    hb.hb_face_destroy(face);
+    hb.free(fontPtr);
+  }
+}
+
+async function readGlyphSet() {
+  const files = await fs.readdir(LETTERS_DIR);
+  const parts = await Promise.all(
+    files.map((f) => fs.readFile(path.join(LETTERS_DIR, f), 'utf8')),
+  );
+  return parts.map((s) => s.replace(/^﻿/, '')).join('');
+}
+
+async function listSrcFonts() {
+  const entries = await fs.readdir(SRC_DIR, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && SRC_EXT.test(e.name))
+    .map((e) => e.name);
+}
+
+async function buildOne(srcFile, text) {
+  const baseName = srcFile.replace(SRC_EXT, '');
+  const input = await fs.readFile(path.join(SRC_DIR, srcFile));
+  let failed = 0;
+
+  for (const { format, ext } of TARGETS) {
+    const outPath = path.join(DIST_DIR, `${baseName}.min.${ext}`);
+    try {
+      const out = await subsetAndStrip(input, text, format);
+      await fs.writeFile(outPath, out);
+      console.log(
+        `  ${path.basename(outPath)}  (${out.length.toLocaleString()} bytes)`,
+      );
+    } catch (e) {
+      failed++;
+      console.error(`  ${path.basename(outPath)} — FAILED: ${e.message}`);
     }
   }
+  return failed;
 }
 
-async function getSrcFonts() {
-  const inputDir = await fs.promises
-    .readdir(config.inputPath)
-    .catch(err => console.error(err));
-
-  return inputDir.filter(fontFile => {
-    return (
-      fs.statSync(config.inputPath + fontFile).isFile() &&
-      /.*\.otf$/.test(fontFile)
-    );
-  });
-}
-
-const subset = async () => {
-  const [text, srcFonts] = await Promise.all([
-    genTextsFromFile(),
-    getSrcFonts(),
-  ]);
-  const tmpTextFile = 'tmpTextFile.txt';
-
-  await fs.promises
-    .writeFile(tmpTextFile, text)
-    .catch(err => console.error(err));
-
-  if (!fs.existsSync(config.outputPath)) {
-    fs.mkdirSync(config.outputPath);
+async function main() {
+  const [text, srcFonts] = await Promise.all([readGlyphSet(), listSrcFonts()]);
+  if (srcFonts.length === 0) {
+    console.error(`No .otf or .ttf files found in ${SRC_DIR}`);
+    process.exit(1);
   }
+  await fs.mkdir(DIST_DIR, { recursive: true });
 
-  srcFonts.forEach((fontFile, fontIndex) => {
-    const reg = /(.*)(?:\.([^.]+$))/;
-    const fontName = fontFile.match(reg)[1];
+  console.log(
+    `Subsetting ${srcFonts.length} font(s) with ${text.length} glyphs:`,
+  );
+  let totalFailed = 0;
+  for (const f of srcFonts) {
+    console.log(`- ${f}`);
+    totalFailed += await buildOne(f, text);
+  }
+  if (totalFailed > 0) {
+    console.error(`\n${totalFailed} target(s) failed.`);
+    process.exit(1);
+  }
+}
 
-    const extensions = ['ttf', 'woff', 'woff2'];
-
-    extensions.forEach((ext, extIndex) => {
-      const flavorOpt =
-        ext === 'woff' || ext === 'woff2' ? `--flavor=${ext} --with-zopfli --desubroutinize` : '';
-      const command = `pyftsubset ./${
-        config.inputPath
-      }${fontFile} --text-file=./${tmpTextFile} --layout-features='*' --output-file=./${
-        config.outputPath
-      }${fontName}.min.${ext} --no-hinting ${flavorOpt}`;
-
-      try {
-        exec(command);
-      } catch (e) {
-        console.error(err);
-      } finally {
-        if (
-          fontIndex + 1 >= srcFonts.length &&
-          extIndex + 1 >= extensions.length
-        ) {
-          fs.unlink(tmpTextFile, err => {
-            if (err) throw err;
-          });
-        }
-      }
-    });
-  });
-};
-
-module.exports = subset();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/index.js
+++ b/index.js
@@ -24,11 +24,18 @@ const TARGETS = [
 const DROP_TABLES = ['GSUB', 'GPOS', 'GDEF', 'kern', 'morx', 'mort'];
 
 const HB_SUBSET_SETS_DROP_TABLE_TAG = 3;
+const HB_SUBSET_FLAGS_NO_HINTING = 0x00000001;
+const HB_SUBSET_FLAGS_DESUBROUTINIZE = 0x00000004;
 const HB_SUBSET_FLAGS_NO_LAYOUT_CLOSURE = 0x00000200;
 
 const hbTag = (s) =>
   s.split('').reduce((a, c) => (a << 8) + c.charCodeAt(0), 0) >>> 0;
 
+const DROP_TAGS = DROP_TABLES.map(hbTag);
+
+// Cached as a module-level singleton: the harfbuzz wasm has a single linear
+// memory, so concurrent subsets would corrupt each other. Safe today because
+// main() drives buildOne() sequentially — revisit if that ever changes.
 let hbInit;
 async function loadHarfbuzz() {
   if (!hbInit) {
@@ -64,21 +71,33 @@ async function subsetToSfnt(originalFont, text) {
   let subset = 0;
   try {
     fontPtr = hb.malloc(sfntInput.byteLength);
+    if (fontPtr === 0) {
+      throw new Error('hb malloc returned zero');
+    }
     heapOf(hb).set(new Uint8Array(sfntInput), fontPtr);
     const blob = hb.hb_blob_create(fontPtr, sfntInput.byteLength, 2, 0, 0);
     face = hb.hb_face_create(blob, 0);
     hb.hb_blob_destroy(blob);
 
     const dropSet = hb.hb_subset_input_set(input, HB_SUBSET_SETS_DROP_TABLE_TAG);
-    for (const tag of DROP_TABLES) {
-      hb.hb_set_add(dropSet, hbTag(tag));
+    for (const tag of DROP_TAGS) {
+      hb.hb_set_add(dropSet, tag);
     }
 
-    // GSUB is being dropped, so layout closure would only waste work and keep
-    // glyphs that aren't reachable without GSUB anyway.
+    // - NO_HINTING strips TT hinting bytecode (no-op for CFF/CFF2 sources but
+    //   meaningful for TTF/glyf inputs).
+    // - DESUBROUTINIZE inlines CFF subroutines: makes the SFNT slightly larger
+    //   on its own, but compresses materially better as WOFF2 — exactly what
+    //   the old `pyftsubset --with-zopfli --desubroutinize` invocation aimed
+    //   for. Important for Noto Sans CJK JP since its outlines are CFF2.
+    // - NO_LAYOUT_CLOSURE: GSUB is being dropped anyway, so closure would only
+    //   waste work and keep glyphs that aren't reachable without GSUB.
     hb.hb_subset_input_set_flags(
       input,
-      hb.hb_subset_input_get_flags(input) | HB_SUBSET_FLAGS_NO_LAYOUT_CLOSURE,
+      hb.hb_subset_input_get_flags(input) |
+        HB_SUBSET_FLAGS_NO_HINTING |
+        HB_SUBSET_FLAGS_DESUBROUTINIZE |
+        HB_SUBSET_FLAGS_NO_LAYOUT_CLOSURE,
     );
 
     const unicodes = hb.hb_subset_input_unicode_set(input);
@@ -114,7 +133,13 @@ async function readGlyphSet() {
 }
 
 async function listSrcFonts() {
-  const entries = await fs.readdir(SRC_DIR, { withFileTypes: true });
+  let entries;
+  try {
+    entries = await fs.readdir(SRC_DIR, { withFileTypes: true });
+  } catch (e) {
+    if (e.code === 'ENOENT') return [];
+    throw e;
+  }
   return entries
     .filter((e) => e.isFile() && SRC_EXT.test(e.name))
     .map((e) => e.name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "noto-sans-cjk-jp.min",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "noto-sans-cjk-jp.min",
+      "version": "2.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "fontverter": "^2.0.0",
+        "harfbuzzjs": "^0.10.3"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/fontverter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fontverter/-/fontverter-2.0.0.tgz",
+      "integrity": "sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "wawoff2": "^2.0.0",
+        "woff2sfnt-sfnt2woff": "^1.0.0"
+      }
+    },
+    "node_modules/harfbuzzjs": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.10.3.tgz",
+      "integrity": "sha512-GJnLUrgLMadlMYrBGEXwYEimObbysy3prWT4HyPpFQERvgTU/OZ+ReUlEPOum6w4RBtFXzXiCCmECOr4sz3qwQ==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/wawoff2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+      "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "woff2_compress.js": "bin/woff2_compress.js",
+        "woff2_decompress.js": "bin/woff2_decompress.js"
+      }
+    },
+    "node_modules/woff2sfnt-sfnt2woff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/woff2sfnt-sfnt2woff/-/woff2sfnt-sfnt2woff-1.0.0.tgz",
+      "integrity": "sha512-edK4COc1c1EpRfMqCZO1xJOvdUtM5dbVb9iz97rScvnTevqEB3GllnLWCmMVp1MfQBdF1DFg/11I0rSyAdS4qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.7"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "start": "node index.js"
   },
+  "dependencies": {
+    "fontverter": "^2.0.0",
+    "harfbuzzjs": "^0.10.3"
+  },
   "keywords": [],
   "author": "hirofumii",
   "license": "ISC",


### PR DESCRIPTION
## Summary

- Replace the broken `pyftsubset` / `child_process` pipeline with an in-process Node subsetter that calls `harfbuzzjs/hb-subset.wasm` directly and wraps output via `fontverter`. No Python toolchain needed; `npm install && npm start` works identically on Windows and Ubuntu.
- Drop the `GSUB` / `GPOS` / `GDEF` / `kern` / `morx` / `mort` tables from the subset output to match the size profile of the historical opentype.jp/woffconv.htm workflow. For `NotoSansCJKjp-VF`, WOFF2 falls from ~1.08 MB to ~955 KB.
- Eliminate the on-disk `tmpTextFile.txt` intermediate, accept both `.otf` and `.ttf` source fonts, and keep going past per-font failures rather than aborting the whole build.
- Add `CLAUDE.md` describing the build pipeline, character set layout under `Letters/`, and the docs/ → GitHub Pages relationship.

## Test plan

- [x] `npm install` from a clean clone (Windows + Ubuntu / WSL)
- [x] Place `NotoSansCJKjp-*.otf` files under `src/` and run `npm start`; verify `dist/*.min.{ttf,woff,woff2}` are produced for every source font
- [x] Confirm `tmpTextFile.txt` is never created during or after a run
- [x] Inspect the generated WOFF2 — the table directory should not contain `GSUB`, `GPOS`, `GDEF`, `kern`, `morx`, or `mort`
- [x] Spot-check a generated WOFF2 in a browser (e.g. drop into `docs/Fonts/NotoSansCJKjp/` and reload `docs/index.html`) to confirm Japanese text still renders
- [x] Compare the dist sizes against the README size table — TTF / WOFF2 should be at or below the previously published values

🤖 Generated with [Claude Code](https://claude.com/claude-code)