### PR TITLE
Automate release with local script and GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create zip from docs/Fonts/NotoSansCJKjp
+        run: |
+          mkdir -p release
+          zip -j "release/NotoSansCJKjp-min-${GITHUB_REF_NAME}.zip" docs/Fonts/NotoSansCJKjp/*.min.*
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            "release/NotoSansCJKjp-min-${GITHUB_REF_NAME}.zip"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This is Subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk
 - WOFF2
 - TTF
 
+## Download
+
+Latest minified font files are published as a zip on the [Releases page](https://github.com/hiz8/Noto-Sans-CJK-JP.min/releases/latest).
+
 ## Size
 
 <!-- size-table:start -->

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is Subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk
 
 ## Size
 
+<!-- size-table:start -->
 | Weight        | otf (Original) | ttf       | woff2    |
 | :------------ | :------------- | :-------- | :------- |
 | Thin          | `14.２ MB`     | `823 KB`  | `529 KB` |
@@ -41,6 +42,7 @@ This is Subset of the [Noto Sans CJK JP](http://www.google.com/get/noto/help/cjk
 | Mono-Regular  | `15.6 MB`      | `817 KB`  | `572 KB` |
 | Mono-Bold     | `16.2 MB`      | `812 KB`  | `580 KB` |
 | Mono-Variable | `28.8 MB`      | `1.52 MB` | `930 KB` |
+<!-- size-table:end -->
 
 ## Packaging Letters
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,59 @@
+# Releasing
+
+This repository ships its built fonts via GitHub Releases. The pipeline is split between a local script (build + commit + tag push) and a GitHub Actions workflow (zip + GitHub Release creation).
+
+## Prerequisites
+
+- Node 18+
+- A clean working tree on `master`
+- Source fonts placed in `src/` (download from [notofonts/noto-cjk releases](https://github.com/notofonts/noto-cjk/releases) and unzip the Noto Sans JP `.otf` files there)
+- `gh` CLI is **not** required — the GitHub Actions workflow uses the auto-provided `GITHUB_TOKEN`
+
+## Steps
+
+1. `npm install`
+2. Place the upstream `.otf` files into `src/`
+3. Preview the release:
+   ```sh
+   npm run release:dry -- --version <new-version>
+   ```
+   This runs `index.js`, prints the new size table, and shows the proposed `package.json` version. **No files outside `dist/` are touched.**
+4. If the preview looks right, publish:
+   ```sh
+   npm run release -- --version <new-version>
+   ```
+   The script will:
+   - Run `index.js`
+   - Copy `dist/*.min.{ttf,woff,woff2}` to `docs/Fonts/NotoSansCJKjp/`
+   - Update the size table in `README.md` (between `<!-- size-table:start -->` and `<!-- size-table:end -->`)
+   - Update `package.json` `version`
+   - Commit, tag (e.g. `3.2.0`), and push (including the tag)
+5. The `.github/workflows/release.yml` workflow fires on the tag push, zips `docs/Fonts/NotoSansCJKjp/*.min.*` into `NotoSansCJKjp-min-<version>.zip`, and creates a GitHub Release with auto-generated release notes.
+
+## Versioning
+
+- Tags follow the existing convention: `1.0.0`, `2.0.0`, `3.0.0`, `3.1.0`, ... (no `v` prefix)
+- The release workflow only fires on tags matching `[0-9]+.[0-9]+.[0-9]+`
+- To record the upstream Noto-CJK version, mention it in the release commit message — `--generate-notes` will surface it in the published release body
+
+## Rollback
+
+- Delete release + tag in one shot:
+  ```sh
+  gh release delete <version> --cleanup-tag --yes
+  ```
+- Revert the source change locally:
+  ```sh
+  git revert HEAD
+  git push
+  ```
+- If you have not yet pushed:
+  ```sh
+  git tag -d <version>
+  git reset --hard HEAD~1
+  ```
+
+## Notes
+
+- The `otf (Original)` column in `README.md` is preserved manually. It reflects upstream OTF sizes, which the release script does not read.
+- `dist/` and `src/` are gitignored. The `docs/Fonts/NotoSansCJKjp/` directory is the canonical, checked-in copy of the latest minified fonts and is what the workflow zips.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Subset of the Noto Sans CJK JP for the size down",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "release": "node scripts/release.mjs",
+    "release:dry": "node scripts/release.mjs --dry-run"
   },
   "dependencies": {
     "fontverter": "^2.0.0",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { copyFile, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const README_PATH = join(repoRoot, 'README.md');
+const PKG_PATH = join(repoRoot, 'package.json');
+const SRC_DIR = join(repoRoot, 'src');
+const DIST_DIR = join(repoRoot, 'dist');
+const DOCS_FONTS_DIR = join(repoRoot, 'docs', 'Fonts', 'NotoSansCJKjp');
+const WIN32 = process.platform === 'win32';
+
+// label -> base file name (without `.min.{ttf,woff2}`).
+// Mirrors the README "Size" table rows and the actual files emitted by
+// index.js. Order here is the order rendered in README.md.
+const WEIGHT_FILES = [
+  ['Thin', 'NotoSansCJKjp-Thin'],
+  ['Light', 'NotoSansCJKjp-Light'],
+  ['DemiLight', 'NotoSansCJKjp-DemiLight'],
+  ['Regular', 'NotoSansCJKjp-Regular'],
+  ['Medium', 'NotoSansCJKjp-Medium'],
+  ['Bold', 'NotoSansCJKjp-Bold'],
+  ['Black', 'NotoSansCJKjp-Black'],
+  ['Variable', 'NotoSansCJKjp-VF'],
+  ['Mono-Regular', 'NotoSansMonoCJKjp-Regular'],
+  ['Mono-Bold', 'NotoSansMonoCJKjp-Bold'],
+  ['Mono-Variable', 'NotoSansMonoCJKjp-VF'],
+];
+const LABEL_WIDTH = WEIGHT_FILES.reduce(
+  (n, [label]) => Math.max(n, label.length),
+  0,
+);
+
+const SIZE_TABLE_START = '<!-- size-table:start -->';
+const SIZE_TABLE_END = '<!-- size-table:end -->';
+
+function fail(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+// On Windows, spawnSync({ shell: true }) hands args to cmd.exe which
+// re-tokenizes them on whitespace. Node does not pre-quote, so a value like
+// "Release 3.0.0" arrives as two tokens and `git commit -m` treats "3.0.0"
+// as a pathspec. Quote any arg with whitespace or cmd meta-characters,
+// doubling embedded `"` per cmd.exe rules.
+function winQuote(arg) {
+  if (arg === '' || /[\s"^&|<>]/.test(arg)) {
+    return `"${String(arg).replace(/"/g, '""')}"`;
+  }
+  return arg;
+}
+
+function spawn(cmd, args, opts) {
+  return spawnSync(cmd, WIN32 ? args.map(winQuote) : args, {
+    cwd: repoRoot,
+    shell: WIN32,
+    ...opts,
+  });
+}
+
+function run(cmd, args) {
+  const result = spawn(cmd, args, { stdio: 'inherit' });
+  if (result.status !== 0) {
+    fail(`${cmd} ${args.join(' ')} exited with code ${result.status}`);
+  }
+}
+
+function runCapture(cmd, args) {
+  return spawn(cmd, args, { encoding: 'utf8' });
+}
+
+function formatSize(bytes) {
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `\`${mb.toFixed(2)} MB\``;
+  const kb = bytes / 1024;
+  return `\`${Math.round(kb)} KB\``;
+}
+
+async function preflight(version, dryRun) {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    fail(`invalid version: ${version} (expected e.g. 3.2.0)`);
+  }
+  const status = runCapture('git', ['status', '--porcelain']);
+  if (status.status !== 0) fail('git status failed');
+  if (status.stdout.trim() !== '') {
+    fail(`working tree is not clean:\n${status.stdout}`);
+  }
+  const tag = runCapture('git', [
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `refs/tags/${version}`,
+  ]);
+  if (tag.status === 0) {
+    fail(`tag ${version} already exists`);
+  }
+  const srcEntries = await readdir(SRC_DIR).catch(() => []);
+  const fonts = srcEntries.filter((f) => /\.(otf|ttf)$/i.test(f));
+  if (fonts.length === 0) {
+    fail('src/ contains no .otf or .ttf files');
+  }
+  console.log(
+    `preflight ok (version ${version}${dryRun ? ', dry-run' : ''}, ${fonts.length} source font(s))`,
+  );
+}
+
+function runBuild() {
+  console.log('--- build ---');
+  run('node', ['index.js']);
+}
+
+async function copyDistToDocs() {
+  console.log('--- copy dist/*.min.* -> docs/Fonts/NotoSansCJKjp/ ---');
+  const files = await readdir(DIST_DIR);
+  const targets = files.filter((f) => /\.min\.(ttf|woff|woff2)$/i.test(f));
+  await Promise.all(
+    targets.map((f) => copyFile(join(DIST_DIR, f), join(DOCS_FONTS_DIR, f))),
+  );
+  console.log(`copied ${targets.length} file(s)`);
+}
+
+function parseOtfColumn(readme) {
+  const map = new Map();
+  const start = readme.indexOf(SIZE_TABLE_START);
+  const end = readme.indexOf(SIZE_TABLE_END);
+  if (start === -1 || end === -1) return map;
+  const block = readme.slice(start, end);
+  // Allow `-` in labels so "Mono-Regular" etc. match.
+  const lineRe = /^\|\s*([\w-]+)\s*\|\s*(`[^`]+`|-)\s*\|/gm;
+  let m;
+  while ((m = lineRe.exec(block)) !== null) {
+    const [, label, value] = m;
+    if (label === 'Weight') continue;
+    map.set(label, value);
+  }
+  return map;
+}
+
+async function buildSizeTable(readme) {
+  const otfMap = parseOtfColumn(readme);
+  const rows = await Promise.all(
+    WEIGHT_FILES.map(async ([label, base]) => {
+      const [ttfStat, woff2Stat] = await Promise.all([
+        stat(join(DIST_DIR, `${base}.min.ttf`)),
+        stat(join(DIST_DIR, `${base}.min.woff2`)),
+      ]);
+      return { label, ttf: ttfStat.size, woff2: woff2Stat.size };
+    }),
+  );
+  const lines = [
+    `| ${'Weight'.padEnd(LABEL_WIDTH)} | otf (Original) | ttf       | woff2     |`,
+    `| ${':'.padEnd(LABEL_WIDTH, '-')} | :------------- | :-------- | :-------- |`,
+  ];
+  for (const { label, ttf, woff2 } of rows) {
+    const otf = otfMap.get(label) ?? '`-`';
+    lines.push(
+      `| ${label.padEnd(LABEL_WIDTH)} | ${otf.padEnd(14)} | ${formatSize(ttf).padEnd(9)} | ${formatSize(woff2).padEnd(9)} |`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function spliceReadme(original, table) {
+  const startIdx = original.indexOf(SIZE_TABLE_START);
+  const endIdx = original.indexOf(SIZE_TABLE_END);
+  if (startIdx === -1 || endIdx === -1) {
+    fail(
+      `README.md is missing size-table markers (${SIZE_TABLE_START} / ${SIZE_TABLE_END})`,
+    );
+  }
+  const before = original.slice(0, startIdx + SIZE_TABLE_START.length);
+  const after = original.slice(endIdx);
+  return `${before}\n${table}\n${after}`;
+}
+
+async function updatePackageVersion(version) {
+  const pkg = JSON.parse(await readFile(PKG_PATH, 'utf8'));
+  console.log(`package.json version: ${pkg.version} -> ${version}`);
+  pkg.version = version;
+  await writeFile(PKG_PATH, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+function gitRelease(version) {
+  console.log('--- git ---');
+  run('git', ['add', 'docs/Fonts/NotoSansCJKjp/', 'README.md', 'package.json']);
+  run('git', ['commit', '-m', `Release ${version}`]);
+  run('git', ['tag', version]);
+  run('git', ['push', '--follow-tags']);
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      version: { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+    },
+    strict: true,
+  });
+  if (!values.version) fail('--version <semver> is required');
+  const version = values.version;
+  const dryRun = values['dry-run'];
+
+  await preflight(version, dryRun);
+  runBuild();
+
+  const readme = await readFile(README_PATH, 'utf8');
+  const table = await buildSizeTable(readme);
+  const nextReadme = spliceReadme(readme, table);
+
+  if (dryRun) {
+    console.log('--- README size table (preview) ---');
+    console.log(table);
+    const pkg = JSON.parse(await readFile(PKG_PATH, 'utf8'));
+    console.log(`package.json version: ${pkg.version} -> ${version}`);
+    console.log('\n--- dry-run summary ---');
+    console.log(
+      'No files modified beyond dist/. Re-run without --dry-run to publish.',
+    );
+    return;
+  }
+
+  await copyDistToDocs();
+  if (nextReadme !== readme) {
+    await writeFile(README_PATH, nextReadme);
+    console.log('README.md size table updated');
+  } else {
+    console.log('README.md size table unchanged');
+  }
+  await updatePackageVersion(version);
+  gitRelease(version);
+  console.log(
+    `\nReleased ${version}. GitHub Actions will create the Release shortly.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Ports [Noto-Serif-CJK-JP.min#5](https://github.com/hiz8/Noto-Serif-CJK-JP.min/pull/5) and its follow-up fix [#6](https://github.com/hiz8/Noto-Serif-CJK-JP.min/pull/6) to this repo, with the Windows quoting fix folded into the initial release script (no broken-then-fixed history).

- Add `scripts/release.mjs` — preflight → `node index.js` → copy `dist/*.min.*` to `docs/Fonts/NotoSansCJKjp/` → refresh README size table (between `<!-- size-table:start -->` / `<!-- size-table:end -->` markers) → bump `package.json` version → commit/tag/push. Includes the `winQuote` helper from PR #6 so `git commit -m "Release X.Y.Z"` does not get re-tokenized by cmd.exe.
- Add `.github/workflows/release.yml` — fires on tag push matching `[0-9]+.[0-9]+.[0-9]+`, zips `docs/Fonts/NotoSansCJKjp/*.min.*` into `NotoSansCJKjp-min-<tag>.zip`, and creates a GitHub Release with auto-generated notes.
- Document the new flow in `docs/RELEASING.md` and link the Releases page from `README.md`.
- New `npm run release` / `npm run release:dry` scripts. **Zero new dependencies** (zip is built in CI on the runner).

## Adaptations from the Serif version

- Build entry point: `build.js` → `index.js`
- Docs fonts directory: `docs/fonts/` → `docs/Fonts/NotoSansCJKjp/` (where this repo's demo serves them)
- Weight set: 8 single-family weights → 11 weights across two families (`NotoSansCJKjp-*` + `NotoSansMonoCJKjp-*`); replaced the simple `WEIGHTS` array + `fileTagFor` with a `WEIGHT_FILES` `[label, basename]` mapping and dynamic label-column width
- Size-table parser regex `\w+` → `[\w-]+` so `Mono-Regular`, `Mono-Bold`, `Mono-Variable` are recognized
- Zip basename: `NotoSerifCJKjp-min-` → `NotoSansCJKjp-min-`

## Why hybrid (local build + CI release)

- Upstream Noto Sans CJK JP source OTFs are large and not checked in (`src/` is gitignored), so a fully-CI build would need to download them from `notofonts/noto-cjk` on every release — slow and fragile.
- `docs/Fonts/NotoSansCJKjp/` is already checked in for the demo site; reusing it as the CI's source for the release zip avoids artifact passing entirely.

## Test plan

- [x] `npm install`, place upstream `.otf` files in `src/`
- [x] `npm run release:dry -- --version 3.2.0-test` — preflight passes, build runs, size-table preview prints (all 11 rows including Mono-*), no commits/tags created
- [ ] Run a real release on a throwaway tag: `npm run release -- --version 3.2.0` (or revert before pushing)
- [ ] Confirm GitHub Actions `Release` workflow runs on tag push and produces a Release with the zip attached
- [ ] Verify rollback: `gh release delete <tag> --cleanup-tag --yes`
- [ ] Confirm preflight rejects: dirty working tree, existing tag, empty `src/`
- [ ] On Windows, confirm `git commit -m "Release X.Y.Z"` succeeds (covers PR #6 fix)